### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/DS1621/keywords.txt
+++ b/DS1621/keywords.txt
@@ -4,14 +4,14 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-DS1621			KEYWORD1
+DS1621	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin			KEYWORD2
-getTemp			KEYWORD2
+begin	KEYWORD2
+getTemp	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################

--- a/HYB_HPSD3000/keywords.txt
+++ b/HYB_HPSD3000/keywords.txt
@@ -4,20 +4,20 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-HYB_HPSD3000		KEYWORD1
+HYB_HPSD3000	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin				KEYWORD2
-getTemp				KEYWORD2
-getTempf			KEYWORD2
-getPressure 		KEYWORD2
-getPressuref		KEYWORD2
+begin	KEYWORD2
+getTemp	KEYWORD2
+getTempf	KEYWORD2
+getPressure	KEYWORD2
+getPressuref	KEYWORD2
 setTempCorrection	KEYWORD2
 setPressCorrection	KEYWORD2
-getRawData			KEYWORD2
+getRawData	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/HexWriter/keywords.txt
+++ b/HexWriter/keywords.txt
@@ -10,14 +10,14 @@ HexWriter	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin		KEYWORD2
-print		KEYWORD2
+begin	KEYWORD2
+print	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
-mode_t		LITERAL1
+mode_t	LITERAL1
 #######################################
 #  (LITERAL2)
 #######################################
-mode		LITERAL2
+mode	LITERAL2

--- a/PCA9536/keywords.txt
+++ b/PCA9536/keywords.txt
@@ -4,20 +4,20 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-PCA9536 			KEYWORD1
+PCA9536	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin				KEYWORD2
-setPinsAsInput		KEYWORD2
-getPinsAsInput		KEYWORD2
-setPinsPolarity		KEYWORD2
-getPinsPolarity		KEYWORD2
-read				KEYWORD2
-readBuffer			KEYWORD2
-write				KEYWORD2
+begin	KEYWORD2
+setPinsAsInput	KEYWORD2
+getPinsAsInput	KEYWORD2
+setPinsPolarity	KEYWORD2
+getPinsPolarity	KEYWORD2
+read	KEYWORD2
+readBuffer	KEYWORD2
+write	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/PCF8577C/keywords.txt
+++ b/PCF8577C/keywords.txt
@@ -4,15 +4,15 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-PCF8577C		KEYWORD1
+PCF8577C	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin			KEYWORD2
-selectBank		KEYWORD2
-write			KEYWORD2
+begin	KEYWORD2
+selectBank	KEYWORD2
+write	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style highlighting  to be used (as with KEYWORD2, KEYWORD3). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special highlighting.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords